### PR TITLE
feat: implement recovery module functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,37 @@ coroutineScope.launch {
 }
 ```
 
+### Recovery module
+
+#### Enable Recovery Module
+
+Android4337 provides a high-level API to enable the recovery module for a Safe Account.
+
+Here is the API we provide:
+
+```kotlin
+fun enableRecoveryModule(guardianAddress: Address, recoveryModuleConfig: RecoveryModuleConfig = RecoveryModuleConfig()): String
+fun getCurrentGuardian(delayAddress: Address): Address?
+fun isRecoveryStarted(delayAddress: Address): Boolean
+fun cancelRecovery(delayAddress: Address): String
+```
+
+- enableRecoveryModule: Enables the recovery module for the safe account by passing the guardian address and the recovery module configuration.
+- getCurrentGuardian: Returns the current guardian address (if any) for the delay module.
+- isRecoveryStarted: Returns true if the recovery process has started.
+- cancelRecovery: Cancels the recovery process (if any).
+
+`RecoveryModuleConfig` describes the configuration used for the recovery module, we provides default values:
+
+```kotlin
+data class RecoveryModuleConfig(
+    val moduleFactoryAddress: String = "0x000000000000aDdB49795b0f9bA5BC298cDda236",
+    val delayModuleAddress: String = "0xd54895B1121A2eE3f37b502F507631FA1331BED6",
+    val recoveryCooldown: Int = 86400,
+    val recoveryExpiration: Int = 604800,
+)
+```
+
 ## Dependencies
 
 Android4337 is built on top of [web3j](https://github.com/hyperledger/web3j), an excellent Java (Android compatible) library for working with web3.

--- a/android4337/src/main/java/io/cometh/android4337/SmartAccount.kt
+++ b/android4337/src/main/java/io/cometh/android4337/SmartAccount.kt
@@ -101,8 +101,7 @@ abstract class SmartAccount(
 
         if (paymasterClient != null) {
             userOperation.signature = signer.getDummySignature()
-            val resp =
-                paymasterClient.pmSponsorUserOperation(userOperation, entryPointAddress).send()
+            val resp = paymasterClient.pmSponsorUserOperation(userOperation, entryPointAddress).send()
             userOperation.signature = null
             if (resp.hasError()) {
                 throw SmartAccountException.PaymasterError("Paymaster cannot sponsor user operation, code: ${resp.error!!.code} ${resp.error.message}")

--- a/android4337/src/main/java/io/cometh/android4337/safe/DelayFactoryModule.kt
+++ b/android4337/src/main/java/io/cometh/android4337/safe/DelayFactoryModule.kt
@@ -1,0 +1,31 @@
+package io.cometh.android4337.safe
+
+import io.cometh.android4337.utils.hexToBigInt
+import io.cometh.android4337.utils.hexToByteArray
+import io.cometh.android4337.utils.toChecksumHex
+import org.web3j.abi.FunctionEncoder
+import org.web3j.abi.TypeReference
+import org.web3j.abi.datatypes.Address
+import org.web3j.abi.datatypes.DynamicBytes
+import org.web3j.abi.datatypes.Function
+import org.web3j.abi.datatypes.generated.Uint256
+
+class DelayModuleFactory {
+    companion object {
+        // deployModule(address, bytes, uint256) returns (address)
+        fun deployModuleFunctionData(
+            singletonDelayAddress: Address,
+            initializer: String,
+            safeAddress: Address
+        ): String {
+            val inputParams = listOf(
+                singletonDelayAddress,
+                DynamicBytes(initializer.hexToByteArray()),
+                Uint256(safeAddress.toChecksumHex().hexToBigInt())
+            )
+            val outputParams = listOf(TypeReference.create(Address::class.java))
+            val function = Function("deployModule", inputParams, outputParams)
+            return FunctionEncoder.encode(function)
+        }
+    }
+}

--- a/android4337/src/main/java/io/cometh/android4337/safe/DelayModule.kt
+++ b/android4337/src/main/java/io/cometh/android4337/safe/DelayModule.kt
@@ -1,0 +1,100 @@
+package io.cometh.android4337.safe
+
+import io.cometh.android4337.utils.encode
+import io.cometh.android4337.utils.hexToByteArray
+import io.cometh.android4337.utils.removeOx
+import io.cometh.android4337.utils.send
+import io.cometh.android4337.utils.toChecksumHexNoPrefix
+import io.cometh.android4337.web3j.Create2
+import org.web3j.abi.DefaultFunctionEncoder
+import org.web3j.abi.FunctionEncoder
+import org.web3j.abi.TypeReference
+import org.web3j.abi.datatypes.Address
+import org.web3j.abi.datatypes.DynamicArray
+import org.web3j.abi.datatypes.DynamicBytes
+import org.web3j.abi.datatypes.Function
+import org.web3j.abi.datatypes.generated.Uint256
+import org.web3j.crypto.Hash
+import org.web3j.protocol.Web3jService
+import java.math.BigInteger
+
+
+class DelayModule {
+    companion object {
+
+        fun predictAddress(
+            safeAddress: Address,
+            recoveryModuleConfig: RecoveryModuleConfig
+        ): String {
+            val initializer = setUpFunctionData(recoveryModuleConfig, safeAddress)
+            val moduleAddress = recoveryModuleConfig.delayModuleAddress
+            val initCodeHash = Hash.sha3("0x602d8060093d393df3363d3d373d3d3d363d73${moduleAddress.removeOx()}5af43d82803e903d91602b57fd5bf3")
+            val salt = Hash.sha3("${Hash.sha3(initializer)}${safeAddress.toChecksumHexNoPrefix().padStart(64, '0')}")
+            val moduleFactoryAddress = recoveryModuleConfig.moduleFactoryAddress
+            return Create2.getCreate2Address(moduleFactoryAddress.removeOx(), salt, initCodeHash)
+        }
+
+        //  getModulesPaginated(address start, uint256 pageSize) returns (address[] memory array, address next) {
+        fun getModulesPaginated(
+            web3jService: Web3jService,
+            contractAddress: Address,
+            start: Address,
+            pageSize: Long
+        ): List<Address> {
+            // getModulesPaginated(address start, uint256 pageSize) external view override returns (address[] memory array, address next)
+            val inputParams = listOf(start, Uint256(pageSize))
+            val outputParams = listOf(
+                object : TypeReference<DynamicArray<Address>>() {},
+                object : TypeReference<Address>() {}
+            )
+            val result = Function("getModulesPaginated", inputParams, outputParams)
+                .send(web3jService, contractAddress)
+            if (result.isEmpty()) return emptyList()
+            return (result[0] as DynamicArray<Address>).value
+        }
+
+        // txNonce() returns (uint256)
+        fun txNonce(web3jService: Web3jService, contractAddress: Address): BigInteger {
+            return Function(
+                "txNonce",
+                emptyList(),
+                listOf(object : TypeReference<Uint256>() {})
+            )
+                .send(web3jService, contractAddress)
+                .let { (it[0] as Uint256).value }
+        }
+
+        fun queueNonce(web3jService: Web3jService, contractAddress: Address): BigInteger {
+            return Function(
+                "queueNonce",
+                emptyList(),
+                listOf(object : TypeReference<Uint256>() {})
+            )
+                .send(web3jService, contractAddress)
+                .let { (it[0] as Uint256).value }
+        }
+
+        fun setTxNonceFunctionData(
+            nonce: BigInteger
+        ): String =
+            Function("setTxNonce", listOf(Uint256(nonce)), emptyList<TypeReference<*>>()).encode()
+
+        // setUp(bytes memory initParams)
+        fun setUpFunctionData(recoveryModuleConfig: RecoveryModuleConfig, safeAddress: Address): String {
+            val recoveryCooldown = recoveryModuleConfig.recoveryCooldown
+            val recoveryExpiration = recoveryModuleConfig.recoveryExpiration
+            val initParams = DefaultFunctionEncoder().encodeParameters(
+                listOf(
+                    safeAddress,
+                    safeAddress,
+                    safeAddress,
+                    Uint256(recoveryCooldown.toBigInteger()),
+                    Uint256(recoveryExpiration.toBigInteger())
+                )
+            )
+            val inputParams = listOf(DynamicBytes("0x$initParams".hexToByteArray()))
+            val outputParams = emptyList<TypeReference<*>>()
+            return FunctionEncoder.encode(Function("setUp", inputParams, outputParams))
+        }
+    }
+}

--- a/android4337/src/main/java/io/cometh/android4337/safe/RecoveryModuleConfig.kt
+++ b/android4337/src/main/java/io/cometh/android4337/safe/RecoveryModuleConfig.kt
@@ -1,0 +1,19 @@
+package io.cometh.android4337.safe
+
+import io.cometh.android4337.utils.requireHexAddress
+import io.cometh.android4337.utils.requirePositive
+
+
+data class RecoveryModuleConfig(
+    val moduleFactoryAddress: String = "0x000000000000aDdB49795b0f9bA5BC298cDda236",
+    val delayModuleAddress: String = "0xd54895B1121A2eE3f37b502F507631FA1331BED6",
+    val recoveryCooldown: Int = 86400,
+    val recoveryExpiration: Int = 604800,
+) {
+    init {
+        moduleFactoryAddress.requireHexAddress()
+        delayModuleAddress.requireHexAddress()
+        recoveryCooldown.requirePositive()
+        recoveryExpiration.requirePositive()
+    }
+}

--- a/android4337/src/main/java/io/cometh/android4337/safe/Safe.kt
+++ b/android4337/src/main/java/io/cometh/android4337/safe/Safe.kt
@@ -233,4 +233,11 @@ object Safe {
         }${encodeUint256(s)}" + "${encodeBytes(authenticatorData)}${encodeBytes(clientDataFieldsBytes)}"
     }
 
+    fun enableModuleFunctionData(moduleAddress: Address): String {
+        val inputParams = listOf(moduleAddress)
+        val outputParams = emptyList<TypeReference<*>>()
+        val function = Function("enableModule", inputParams, outputParams)
+        return FunctionEncoder.encode(function)
+    }
+
 }

--- a/android4337/src/main/java/io/cometh/android4337/web3j/AbiEncoder.kt
+++ b/android4337/src/main/java/io/cometh/android4337/web3j/AbiEncoder.kt
@@ -4,7 +4,7 @@ import org.web3j.abi.datatypes.Type
 
 object AbiEncoder {
 
-    fun encodePackedParameters(parameters: List<Type<*>>): String {
+    fun encodePackedParameters(parameters: List<Type<*>>, padAddress: Boolean = false): String {
         val result = StringBuilder()
         for (parameter in parameters) {
             result.append(TypeEncoder.encodePacked(parameter))

--- a/android4337/src/test/java/io/cometh/android4337/safe/DelayModuleFactoryTest.kt
+++ b/android4337/src/test/java/io/cometh/android4337/safe/DelayModuleFactoryTest.kt
@@ -1,0 +1,21 @@
+package io.cometh.android4337.safe
+
+import io.cometh.android4337.utils.hexToAddress
+import org.junit.Assert
+import org.junit.Test
+
+class DelayModuleFactoryTest {
+
+    @Test
+    fun getDeployModuleFunctionData() {
+        val expected = "0xf1ab873c000000000000000000000000d54895b1121a2ee3f37b502f507631fa1331bed600000000000000000000000000000000000000000000000000000000000000600000000000000000000000004bf81eef3911db0615297836a8ff351f5fe08c680000000000000000000000000000000000000000000000000000000000000002aaaa000000000000000000000000000000000000000000000000000000000000"
+        val config = RecoveryModuleConfig()
+        DelayModuleFactory.deployModuleFunctionData(
+            config.delayModuleAddress.hexToAddress(),
+            "0xaaaa",
+            TestsData.account1SafeAddress.hexToAddress()
+        ).let {
+            Assert.assertEquals(expected, it)
+        }
+    }
+}

--- a/android4337/src/test/java/io/cometh/android4337/safe/DelayModuleTest.kt
+++ b/android4337/src/test/java/io/cometh/android4337/safe/DelayModuleTest.kt
@@ -1,0 +1,36 @@
+package io.cometh.android4337.safe
+
+import io.cometh.android4337.utils.hexToAddress
+import org.junit.Assert
+import org.junit.Test
+import java.math.BigInteger
+
+class DelayModuleTest {
+
+    @Test
+    fun predictAddress() {
+        val expected = "0x9b24CE7A4d940920c479f26d9460F6195C1e86ab"
+        val delayAddress = DelayModule.predictAddress(
+            TestsData.account1SafeAddress.hexToAddress(),
+            RecoveryModuleConfig()
+        )
+        Assert.assertEquals(expected, delayAddress)
+    }
+
+    @Test
+    fun getSetTxNonceFunctionData() {
+        val expected = "0x46ba23070000000000000000000000000000000000000000000000000000000000000001"
+        val setTxNonceFunctionData = DelayModule.setTxNonceFunctionData(BigInteger.ONE)
+        Assert.assertEquals(expected, setTxNonceFunctionData)
+    }
+
+    @Test
+    fun getSetUpFunctionData() {
+        val expected = "0xa4f9edbf000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000004bf81eef3911db0615297836a8ff351f5fe08c680000000000000000000000004bf81eef3911db0615297836a8ff351f5fe08c680000000000000000000000004bf81eef3911db0615297836a8ff351f5fe08c6800000000000000000000000000000000000000000000000000000000000151800000000000000000000000000000000000000000000000000000000000093a80"
+        val setUpFunctionData = DelayModule.setUpFunctionData(
+            RecoveryModuleConfig(),
+            TestsData.account1SafeAddress.hexToAddress(),
+        )
+        Assert.assertEquals(expected, setUpFunctionData)
+    }
+}

--- a/android4337/src/test/java/io/cometh/android4337/safe/SafeAccountTest.kt
+++ b/android4337/src/test/java/io/cometh/android4337/safe/SafeAccountTest.kt
@@ -6,28 +6,36 @@ import io.cometh.android4337.EntryPointContract
 import io.cometh.android4337.HttpResponseStub
 import io.cometh.android4337.UserOperation
 import io.cometh.android4337.bundler.BundlerClient
+import io.cometh.android4337.bundler.SimpleBundlerClient
 import io.cometh.android4337.gasprice.UserOperationGasPriceProvider
+import io.cometh.android4337.mockBundlerEstimateUserOperation
+import io.cometh.android4337.mockGasEstimateGetGasPrice
+import io.cometh.android4337.mockGetNonce
+import io.cometh.android4337.mockPaymasterSponsorUserOperation
 import io.cometh.android4337.paymaster.PaymasterClient
 import io.cometh.android4337.safe.signer.eoa.EOASigner
 import io.cometh.android4337.safe.signer.passkey.Passkey
 import io.cometh.android4337.safe.signer.passkey.PasskeySigner
 import io.cometh.android4337.toInputStream
+import io.cometh.android4337.utils.hexToAddress
 import io.cometh.android4337.utils.hexToBigInt
 import io.cometh.android4337.utils.toHex
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.web3j.tx.TransactionManager
+import java.io.ByteArrayInputStream
 
 class SafeAccountTest {
 
-    @MockK
-    lateinit var bundlerClient: BundlerClient
+//    @MockK
+//    lateinit var bundlerClient: BundlerClient
 
     @MockK
     lateinit var gasPriceProvider: UserOperationGasPriceProvider
@@ -47,11 +55,13 @@ class SafeAccountTest {
     lateinit var safeAccount1: SafeAccount
     lateinit var safeAccount2: SafeAccount
     lateinit var web3Service: CustomHttpService
+    lateinit var bundlerClient: BundlerClient
 
     @Before
     fun before() {
         MockKAnnotations.init(this)
         web3Service = CustomHttpService(httpResponseStub)
+        bundlerClient = SimpleBundlerClient(web3Service)
         safeAccount1 = SafeAccount.fromAddress(
             address = TestsData.account1SafeAddress,
             EOASigner(TestsData.account1Credentials),
@@ -86,12 +96,6 @@ class SafeAccountTest {
             gasPriceProvider = gasPriceProvider,
         )
         assertEquals(TestsData.account1SafeAddress, safeAccount.safeAddress)
-    }
-
-
-    @Test
-    fun getFactory() {
-
     }
 
     @Test
@@ -145,8 +149,7 @@ class SafeAccountTest {
                     )
                 ),
                 web3Service,
-
-                )
+            )
         }
         assertEquals("0xfF724471DcB34e42C715163B60A0881fAF7a9C96", address)
     }
@@ -223,4 +226,65 @@ class SafeAccountTest {
         assertEquals(expected, signature.toHex())
     }
 
+    @Test(expected = Error::class)
+    fun enableRecoveryModule_alreadyEnabled() {
+        every { httpResponseStub.getResponse(any()) } returns """
+            { "jsonrpc": "2.0", "id": 1, "result": "0xabcd" }
+        """.trimIndent().toInputStream()
+        safeAccount1.enableRecoveryModule(
+            guardianAddress = "0x2f920a66c2f9760f6fe5f49b289322ddf60f9103".hexToAddress(),
+        )
+    }
+
+    @Test
+    fun enableRecoveryModule() {
+        val delayIsDeployedResp = """{ "jsonrpc": "2.0", "id": 1, "result": "0x" }""".toIS()
+        val accountIsDeployedResp = """{ "jsonrpc": "2.0", "id": 1, "result": "0xaaaa" }""".toIS()
+        every {
+            httpResponseStub.getResponse(match { it.contains("eth_getCode") })
+        } returns delayIsDeployedResp andThen accountIsDeployedResp
+        mockGetNonce(httpResponseStub)
+        mockBundlerEstimateUserOperation(httpResponseStub)
+        mockGasEstimateGetGasPrice(gasPriceProvider)
+        mockPaymasterSponsorUserOperation(paymasterClient)
+
+        val sendUserOpResp = """{ "jsonrpc": "2.0", "id": 1, "result": "0x" }""".toIS()
+        every {
+            httpResponseStub.getResponse(match { it.contains("eth_sendUserOperation") })
+        } returns sendUserOpResp
+
+        safeAccount1.enableRecoveryModule(
+            guardianAddress = "0x2f920a66c2f9760f6fe5f49b289322ddf60f9103".hexToAddress(),
+        )
+
+        verify {
+            httpResponseStub.getResponse(
+                """{
+  "jsonrpc" : "2.0",
+  "method" : "eth_sendUserOperation",
+  "params" : [ {
+    "sender" : "0x4bF81EEF3911db0615297836a8fF351f5Fe08c68",
+    "nonce" : "0x03",
+    "callData" : "0x7bb3742800000000000000000000000038869bf66a61cf6bdb996a6ae40d5853fd43b52600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000003248d80ff0a000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000002cb00000000000000addb49795b0f9ba5bc298cdda23600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000184f1ab873c000000000000000000000000d54895b1121a2ee3f37b502f507631fa1331bed600000000000000000000000000000000000000000000000000000000000000600000000000000000000000004bf81eef3911db0615297836a8ff351f5fe08c6800000000000000000000000000000000000000000000000000000000000000e4a4f9edbf000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000004bf81eef3911db0615297836a8ff351f5fe08c680000000000000000000000004bf81eef3911db0615297836a8ff351f5fe08c680000000000000000000000004bf81eef3911db0615297836a8ff351f5fe08c6800000000000000000000000000000000000000000000000000000000000151800000000000000000000000000000000000000000000000000000000000093a8000000000000000000000000000000000000000000000000000000000004bf81eef3911db0615297836a8ff351f5fe08c6800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000024610b59250000000000000000000000009b24ce7a4d940920c479f26d9460f6195c1e86ab009b24ce7a4d940920c479f26d9460f6195c1e86ab00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000024610b59250000000000000000000000002f920a66c2f9760f6fe5f49b289322ddf60f910300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "callGasLimit" : "0x163a2",
+    "verificationGasLimit" : "0x1b247",
+    "preVerificationGas" : "0xef1c",
+    "maxFeePerGas" : "0x01e3fb094e",
+    "maxPriorityFeePerGas" : "0x53cd81aa",
+    "signature" : "0x000000000000000000000000e6e83e86c6f56595a8cd818957255e84aa98c1b22f4d5e324dd53e69a7198bd93bc150d1f93e47952116bf21cb5800c14edffdcbfaaf6cf3e468afa9afdfdd951b",
+    "paymaster" : "0x4685d9587a7F72Da32dc323bfFF17627aa632C61",
+    "paymasterVerificationGasLimit" : "0x4e09",
+    "paymasterPostOpGasLimit" : "0x1",
+    "paymasterData" : "0xDFF7FA1077Bce740a6a212b3995990682c0Ba66d000000000000000000000000000000000000000000000000000000006672ce7100000000000000000000000000000000000000000000000000000000000000000e499f53c85c53cd4f1444b807e380c6a01a412d7e1cfd24b6153debb97cbc986e6809dff8c005ed94c32bf1d5e722b9f40b909fc89d8982f2f99cb7a91b19f01c"
+  }, "0x0000000071727De22E5E9d8BAf0edAc6f37da032" ],
+  "id" : 4
+}""".trimIndent().replace("\n", "").replace(" ", "")
+            )
+        }
+    }
+
+}
+
+fun String.toIS(): ByteArrayInputStream {
+    return trimIndent().toInputStream()
 }

--- a/android4337/src/test/java/io/cometh/android4337/safe/SafeTest.kt
+++ b/android4337/src/test/java/io/cometh/android4337/safe/SafeTest.kt
@@ -79,5 +79,4 @@ class SafeTest {
         )
     }
 
-
 }

--- a/example/src/main/java/io/cometh/sample4337/MainActivity.kt
+++ b/example/src/main/java/io/cometh/sample4337/MainActivity.kt
@@ -25,7 +25,7 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             var tabIndex by remember { mutableStateOf(0) }
-            val tabs = listOf("Shared Signer", "Deployed Signer", "Connect Api")
+            val tabs = listOf("Shared Signer", "Deployed Signer", "Connect", "Recovery")
             Android4337Theme {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
                     Surface(modifier = Modifier.padding(top = 32.dp)) {
@@ -41,6 +41,7 @@ class MainActivity : ComponentActivity() {
                             0 -> SharedPasskeySignerScreen()
                             1 -> PasskeySignerScreen()
                             2 -> ConnectApiScreen()
+                            3 -> RecoveryModuleScreen()
                         }
                     }
                 }

--- a/example/src/main/java/io/cometh/sample4337/RecoveryModuleScreen.kt
+++ b/example/src/main/java/io/cometh/sample4337/RecoveryModuleScreen.kt
@@ -1,0 +1,169 @@
+package io.cometh.sample4337
+
+import android.util.Log
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.cometh.android4337.bundler.SimpleBundlerClient
+import io.cometh.android4337.paymaster.PaymasterClient
+import io.cometh.android4337.safe.SafeAccount
+import io.cometh.android4337.safe.signer.passkey.PasskeySigner
+import io.cometh.android4337.utils.hexToAddress
+import io.cometh.android4337.utils.toHex
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.web3j.crypto.Credentials
+import org.web3j.protocol.Web3j
+import org.web3j.protocol.core.DefaultBlockParameterName
+import org.web3j.protocol.http.HttpService
+import org.web3j.utils.Convert
+
+@Composable
+fun RecoveryModuleScreen() {
+    val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
+    var signUpResult by remember { mutableStateOf("") }
+    var safeAddress by remember { mutableStateOf("") }
+    var safeBalance by remember { mutableStateOf("") }
+    var safeAccount: SafeAccount? by remember { mutableStateOf(null) }
+    var currentGuardianResult by remember { mutableStateOf("") }
+    var isRecoveryStartedResult by remember { mutableStateOf("") }
+    var cancelRecoveryResult by remember { mutableStateOf("") }
+    var messageResult by remember { mutableStateOf("") }
+
+    val chainId = 84532
+    val rpcService = HttpService("https://base-sepolia.g.alchemy.com/v2/UEwp8FtpdjcL5oekF6CjMzxe1D3768XU")
+    val bundlerClient = SimpleBundlerClient(HttpService("https://bundler.cometh.io/$chainId/?apikey=Y3dZHg2cc2qOT9ukzvxZZ7jEloTqx5rx"))
+    val credentials = Credentials.create("4bddaeef5fb283e847abf0bd480a771b7695d70f413b248dc56c0bb1bb4a0b86")
+    val paymasterClient = PaymasterClient("https://paymaster.cometh.io/$chainId?apikey=Y3dZHg2cc2qOT9ukzvxZZ7jEloTqx5rx")
+
+    val rpId = "sample4337.cometh.io"
+    val userName = "my_user"
+
+    Log.i("SignUpScreen", "credentials.address=${credentials.address}")
+
+    LaunchedEffect(safeAddress) {
+        coroutineScope.launch {
+            withContext(Dispatchers.IO) {
+                if (safeAddress.isNotEmpty()) {
+                    Log.i("SignUpScreen", "ethGetBalance=$safeAddress")
+                    val balance = Web3j.build(rpcService).ethGetBalance(safeAddress, DefaultBlockParameterName.LATEST).send().balance
+                    // convert balance to eth
+                    val ethBalance = Convert.fromWei(balance.toString(), Convert.Unit.ETHER)
+                    safeBalance = "$ethBalance ETH"
+                }
+            }
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        if (PasskeySigner.hasSavedPasskey(context, rpId, userName)) {
+            val passkeySigner = PasskeySigner.withSharedSigner(context, rpId, userName)
+            coroutineScope.launch {
+                withContext(Dispatchers.IO) {
+                    safeAccount = SafeAccount.createNewAccount(
+                        bundlerClient = bundlerClient,
+                        chainId = chainId,
+                        web3Service = rpcService,
+                        signer = passkeySigner,
+                        paymasterClient = paymasterClient
+                    )
+                    signUpResult = """
+                        Passkey Loaded ✅
+                        x=${passkeySigner.passkey.x.toHex()}
+                        y=${passkeySigner.passkey.y.toHex()}
+                        recoveryAddress=${safeAccount!!.predictDelayModuleAddress()}
+                    """.trimIndent()
+                    safeAddress = safeAccount!!.accountAddress
+                    Log.i("SignUpScreen", "accountAddress=$safeAddress")
+                    Log.i("SignUpScreen", signUpResult)
+                }
+            }
+        }
+    }
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(text = signUpResult, fontSize = 12.sp)
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(text = messageResult, fontSize = 12.sp)
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(onClick = {
+            coroutineScope.launch {
+                withContext(Dispatchers.IO) {
+                    val signature = safeAccount!!.enableRecoveryModule(
+                        guardianAddress = "0x2f920a66c2f9760f6fe5f49b289322ddf60f9103".hexToAddress(),
+                    )
+                }
+            }
+        }) {
+            Text(text = "Enable Recovery Module")
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        // get_current_guardian
+        Button(onClick = {
+            coroutineScope.launch {
+                withContext(Dispatchers.IO) {
+                    val guardianAddress = safeAccount!!.getCurrentGuardian(safeAccount!!.predictDelayModuleAddress().hexToAddress())
+                    currentGuardianResult = "Current guardian: $guardianAddress"
+                }
+            }
+        }) {
+            Text(text = "Get current guardian")
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(text = currentGuardianResult, fontSize = 12.sp)
+        Spacer(modifier = Modifier.height(16.dp))
+        // is_recovery_started
+        Button(onClick = {
+            coroutineScope.launch {
+                withContext(Dispatchers.IO) {
+                    val isRecoveryStarted = safeAccount!!.isRecoveryStarted(safeAccount!!.predictDelayModuleAddress().hexToAddress())
+                    isRecoveryStartedResult = "Is recovery started: ${if (isRecoveryStarted) "✅Yes" else "No"}"
+                }
+            }
+        }) {
+            Text(text = "Is recovery started ?")
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(text = isRecoveryStartedResult, fontSize = 12.sp)
+        Spacer(modifier = Modifier.height(16.dp))
+        // cancel_recovery
+        Button(onClick = {
+            coroutineScope.launch {
+                withContext(Dispatchers.IO) {
+                    try {
+                        val signature = safeAccount!!.cancelRecovery(safeAccount!!.predictDelayModuleAddress().hexToAddress())
+                        cancelRecoveryResult = "Cancel recovery signature: $signature"
+                    } catch (e: Exception) {
+                        cancelRecoveryResult = "Cancel recovery failed: ${e.message}"
+                    }
+                }
+            }
+        }) {
+            Text(text = "Cancel recovery")
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(text = cancelRecoveryResult, fontSize = 12.sp)
+        Spacer(modifier = Modifier.height(16.dp))
+    }
+}

--- a/example/src/main/java/io/cometh/sample4337/SharedPasskeySignerScreen.kt
+++ b/example/src/main/java/io/cometh/sample4337/SharedPasskeySignerScreen.kt
@@ -255,8 +255,5 @@ fun SharedPasskeySignerScreen() {
         }) {
             Text(text = "Sign Message")
         }
-        Spacer(modifier = Modifier.height(16.dp))
-        Text(text = messageResult, fontSize = 12.sp)
-        Spacer(modifier = Modifier.height(16.dp))
     }
 }


### PR DESCRIPTION
### Recovery module

Android4337 provides a high-level API to enable the recovery module for a Safe Account.

- **enableRecoveryModule**: Enables the recovery module for the safe account by passing the guardian address and the recovery module configuration.
- **getCurrentGuardian**: Returns the current guardian address (if any) for the delay module.
- **isRecoveryStarted**: Returns true if the recovery process has started.
- **cancelRecovery**: Cancels the recovery process (if any).